### PR TITLE
Re-disable touch selection.

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -28,14 +28,14 @@ body {
   background: #f2f2f2;
 }
 
-/* * {
+.timer {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-} */
+}
 
 
 .timer-app {


### PR DESCRIPTION
This is nice to have disabled, otherwise when you're hodling your finger
down waiting to start, my browser (Chrome on Android) starts to select
the text on the screen, which is definitely not what I want.

This code was commented out in
http://github.com/cubing/timer/commit/9e7a49816d6865d4b8a9a2e7d3e4a582318252d7,
but it's not clear why. I lightly tested this change, and listing times
does still seem to work.